### PR TITLE
refactor: move webpack dev patch into file

### DIFF
--- a/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/mfe-webpack-dev-config
+++ b/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/mfe-webpack-dev-config
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+// If this is the Library Authoring MFE, serve xblock-bootstrap.html statically.
+if (fs.existsSync("src/library-authoring/edit-block/LibraryBlock/xblock-bootstrap.html")) {
+  const path = require('path');
+  const CopyPlugin = require('copy-webpack-plugin');
+
+  module.exports.plugins.push(
+    new CopyPlugin({
+      patterns: [{
+        context: path.resolve(__dirname, 'src/library-authoring/edit-block/LibraryBlock'),
+        from: 'xblock-bootstrap.html',
+      }],
+    }),
+  );
+}

--- a/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/plugin.py
+++ b/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/plugin.py
@@ -77,26 +77,3 @@ for path in glob(
 ):
     with open(path, encoding="utf-8") as patch_file:
         tutor_hooks.Filters.ENV_PATCHES.add_item((os.path.basename(path), patch_file.read()))
-
-# Tutor overwrites webpack.dev.config.js, but this MFE depends on some code
-# in that file to work correctly so we have to restore it here manually.
-# https://github.com/openedx/frontend-app-library-authoring/blob/b95c198b/webpack.dev.config.js
-tutor_hooks.Filters.ENV_PATCHES.add_item(("mfe-webpack-dev-config","""
-const fs = require('fs');
-
-// If this is the Library Authoring MFE, apply this fix:
-if (fs.existsSync("src/library-authoring/edit-block/LibraryBlock/xblock-bootstrap.html")) {
-    const path = require('path');
-    const CopyWebpackPlugin = require('copy-webpack-plugin');
-    module.exports = merge(module.exports, {
-    plugins: [
-        new CopyWebpackPlugin({
-        patterns: [{
-            context: path.resolve(__dirname, 'src/library-authoring/edit-block/LibraryBlock'),
-            from: 'xblock-bootstrap.html',
-        }],
-        }),
-    ],
-    });
-}
-"""))


### PR DESCRIPTION
Move the mfe-webpack-dev-config patch into its own file.

And in doing so, remove the dependency on `webpack-merge`.