### PR TITLE
fix: make annotation Python 3.8 compatible

### DIFF
--- a/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/plugin.py
+++ b/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/plugin.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from glob import glob
 import os
 import pkg_resources


### PR DESCRIPTION
This annotation format doesn't work by default in Python 3.8:

    MY_INIT_TASKS: list[tuple[str, tuple[str, ...]]] = [
        ("cms", ("library_authoring_mfe", "jobs", "init", "cms.sh")),
    ]

To get it to work properly, we need to do the "from __future__ import annotations" line.