### PR TITLE
fix: Add the missing MFE dev images

### DIFF
--- a/plugins/tutor-contrib-learner-dashboard-mfe/tutor_learner_dashboard_mfe/plugin.py
+++ b/plugins/tutor-contrib-learner-dashboard-mfe/tutor_learner_dashboard_mfe/plugin.py
@@ -57,6 +57,20 @@ for service, template_path in MY_INIT_TASKS:
 
 
 ########################################
+# DOCKER IMAGE MANAGEMENT
+########################################
+
+# Add the -dev image.
+hooks.Filters.IMAGES_BUILD.add_item(
+    (
+        "learner-dashboard-dev",
+        ("plugins", "mfe", "build", "mfe"),
+        "{{ DOCKER_REGISTRY }}overhangio/openedx-learner-dashboard-dev:{{ MFE_VERSION }}",
+        (f"--target=learner-dashboard-dev",),
+    )
+)
+
+########################################
 # PATCH LOADING
 ########################################
 

--- a/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/plugin.py
+++ b/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/plugin.py
@@ -54,6 +54,20 @@ for service, template_path in MY_INIT_TASKS:
     tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item((service, init_task))
 
 ########################################
+# DOCKER IMAGE MANAGEMENT
+########################################
+
+# Add the -dev image.
+tutor_hooks.Filters.IMAGES_BUILD.add_item(
+    (
+        "library-authoring-dev",
+        ("plugins", "mfe", "build", "mfe"),
+        "{{ DOCKER_REGISTRY }}overhangio/openedx-library-authoring-dev:{{ MFE_VERSION }}",
+        (f"--target=library-authoring-dev",),
+    )
+)
+
+########################################
 # TEMPLATE RENDERING
 ########################################
 


### PR DESCRIPTION
Even though plugins based on `tutor-mfe` need not add production images, they still need to add the `*-dev` ones, otherwise `tutor dev launch` will fail.