### PR TITLE
fix: remove line requiring fs from patch

### DIFF
--- a/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/mfe-webpack-dev-config
+++ b/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/mfe-webpack-dev-config
@@ -1,5 +1,3 @@
-const fs = require('fs');
-
 // If this is the Library Authoring MFE, serve xblock-bootstrap.html statically.
 if (fs.existsSync("src/library-authoring/edit-block/LibraryBlock/xblock-bootstrap.html")) {
   const path = require('path');


### PR DESCRIPTION
This was causing other MFEs to fail because tutor-mfe already declares "const fs" and the merged `webpack.dev-tutor.config.js` file would have both, causing a syntax error.