### PR TITLE
fix: add login and CORS config for library authoring MFE

### DIFF
--- a/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/openedx-cms-development-settings
+++ b/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/openedx-cms-development-settings
@@ -1,1 +1,3 @@
 LIBRARY_AUTHORING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ library_authoring_port }}/library-authoring"
+CORS_ORIGIN_WHITELIST.append("http://{{ MFE_HOST }}:{{ library_authoring_port }}")
+LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ library_authoring_port }}")

--- a/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/openedx-cms-production-settings
+++ b/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/openedx-cms-production-settings
@@ -1,1 +1,3 @@
 LIBRARY_AUTHORING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/library-authoring"
+CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")
+LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")


### PR DESCRIPTION
Without this Studio configuration, login and REST API requests from the library authoring MFE will fail.