### PR TITLE
fix(library-authoring): the MFE was not on the CSRF allowlist

### DIFF
--- a/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/openedx-cms-development-settings
+++ b/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/openedx-cms-development-settings
@@ -1,3 +1,4 @@
 LIBRARY_AUTHORING_MICROFRONTEND_URL = "http://{{ MFE_HOST }}:{{ get_mfe('library-authoring')['port'] }}/library-authoring/"
 CORS_ORIGIN_WHITELIST.append("http://{{ MFE_HOST }}:{{ get_mfe('library-authoring')['port'] }}")
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}:{{ get_mfe('library-authoring')['port'] }}")
+CSRF_TRUSTED_ORIGINS.append("http://{{ MFE_HOST }}:{{ get_mfe('library-authoring')['port'] }}")

--- a/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/openedx-cms-production-settings
+++ b/plugins/tutor-contrib-library-authoring-mfe/tutor_library_authoring_mfe/patches/openedx-cms-production-settings
@@ -1,3 +1,4 @@
 LIBRARY_AUTHORING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/library-authoring/"
 CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")
 LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
+CSRF_TRUSTED_ORIGINS.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")


### PR DESCRIPTION
When trying to create a library on my tutor devstack, I got a 403 error. This fixed it. Not sure why it wasn't needed before?

This matches what's [upstream for `course-authoring`](https://github.com/overhangio/tutor-mfe/blob/5b08860e0874441def694e17c8a28e714501c17a/tutormfe/patches/openedx-cms-development-settings).