### PR TITLE
Have git ignore Mac .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
```
chore: add root .gitignore file and ignore .DS_Store

So that devs running Macs won't check in metadata garbage.
```