### PR TITLE
fix: update paragon build command options

### DIFF
--- a/plugins/tutor-contrib-paragon/README.rst
+++ b/plugins/tutor-contrib-paragon/README.rst
@@ -107,8 +107,11 @@ Available options:
 - ``--source-tokens-only``  
   Include only source design tokens in the build.
 
-- ``--output-token-references``  
-  Include references for tokens with aliases to other tokens in the build output.
+- ``--output-token-references/--no-output-token-references``  
+  Include references for tokens with aliases to other tokens in the build (default: enabled).
+
+- ``--exclude-core``  
+  Exclude core from the token build.
 
 - ``--themes <theme1,theme2>``  
   Comma-separated list of theme names to compile. Defaults to the list defined in ``PARAGON_ENABLED_THEMES`` if not provided.
@@ -132,6 +135,12 @@ Examples
 
     # Compile only source tokens for a single theme
     tutor local do paragon-build-tokens --themes theme-1 --source-tokens-only
+
+    # Compile without outputting token references
+    tutor local do paragon-build-tokens --no-output-token-references
+
+    # Compile excluding core tokens
+    tutor local do paragon-build-tokens --exclude-core
 
 Output
 ------

--- a/plugins/tutor-contrib-paragon/tutorparagon/commands.py
+++ b/plugins/tutor-contrib-paragon/tutorparagon/commands.py
@@ -17,10 +17,15 @@ import click
     help="Include only source design tokens in the build.",
 )
 @click.option(
-    "--output-token-references",
+    "--output-token-references/--no-output-token-references",
+    default=True,
+    help="Include references for tokens with aliases to other tokens in the build.",
+)
+@click.option(
+    "--exclude-core",
     is_flag=True,
     default=False,
-    help="Include references for tokens with aliases to other tokens in the build output.",
+    help="Exclude core from the token build.",
 )
 @click.option("--themes", help="Comma-separated list of themes to build.")
 @click.option(
@@ -29,6 +34,7 @@ import click
 def paragon_build_tokens(
     source_tokens_only: bool,
     output_token_references: bool,
+    exclude_core: bool,
     themes: str,
     verbose: bool,
 ) -> list[tuple[str, str]]:
@@ -38,6 +44,7 @@ def paragon_build_tokens(
     Args:
         source_tokens_only (bool): Only source design tokens.
         output_token_references (bool): Output token references.
+        exclude_core (bool): Exclude core from the token build.
         themes (str): Comma-separated list of themes.
         verbose (bool): Verbose logging.
 
@@ -47,8 +54,10 @@ def paragon_build_tokens(
     args = []
     if source_tokens_only:
         args.append("--source-tokens-only")
-    if output_token_references:
-        args.append("--output-token-references")
+    if not output_token_references:
+        args.append("--output-references=false")
+    if exclude_core:
+        args.append("--exclude-core")
     if themes:
         args.append("--themes")
         args.append(themes)


### PR DESCRIPTION
## Description

This PR corrects the behavior of the `--output-token-references` option so it properly toggles token-reference output, and adds support for the existing `--exclude-core` feature in the Python CLI binding.

## Key Changes

* **Fix `--output-token-references`**
  * Converted from a one-way flag into a true boolean toggle (`--output-token-references/--no-output-token-references`), with references enabled by default.
 
* **Add support for `--exclude-core`**
  * Introduce a new `--exclude-core` flag to the `paragon-build-tokens` command, giving users the option to omit the core token set from the build output.

All related function docstrings, CLI help text, and README examples have been updated to reflect these changes.
