### PR TITLE
fix: Update to use the upstream store.

### DIFF
--- a/plugins/tutor-contrib-ltistore/tutor_ltistore/plugin.py
+++ b/plugins/tutor-contrib-ltistore/tutor_ltistore/plugin.py
@@ -21,7 +21,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # so we're making this a config value you can change.
         (
             "LTISTORE_PIP_INSTALL",
-            "git+https://github.com/feanil/openedx-ltistore.git@feanil/minimal_lti1p3_fixes",
+            "openedx-ltistore",
         ),
     ]
 )


### PR DESCRIPTION
Our changes have been merged and released upstream so we can just use
the default version of the store again.
