### PR TITLE
chore(deps): update tutor-mfe to >= 20.1.0

### DIFF
--- a/plugins/tutor-contrib-paragon/pyproject.toml
+++ b/plugins/tutor-contrib-paragon/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "tutor>=19.0.0,<21.0.0",
-    "tutor-mfe>=20.1.0",
+    "tutor-mfe>=20.1.0,<21.0.0",
 ]
 
 optional-dependencies = { dev = ["tutor[dev]>=19.0.0,<21.0.0", "pytest>=8.3.4", "pytest-order>=1.3.0", "requests>=2.32.2"] }


### PR DESCRIPTION
## Description
This pull request updates the dependency specification for the `tutor-contrib-paragon` plugin to use the newly released `tutor-mfe` version `>=20.1.0` from PyPI. Previously, the plugin depended on a release-branch source.

Closes #50