### PR TITLE
docs(readme): add tutor-contrib-paragon to plugins table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ tutor-contrib-learner-dashboard-mfe  Deprecated
 tutor-contrib-test-legacy-js         "Production" (Supported For Developers)
 tutor-contrib-scout-apm              Experimental
 tutor-contrib-lti-store              Experimental
-tutor-contrib-paragon                Experimental
+tutor-contrib-paragon                Production
 ===================================  ======================================================
 
 Getting Started


### PR DESCRIPTION
## Description
Added `tutor-contrib-paragon` to the README plugins table as Experimental.

Closes #51