### PR TITLE
fix: support tutor v21

### DIFF
--- a/plugins/tutor-contrib-ltistore/pyproject.toml
+++ b/plugins/tutor-contrib-ltistore/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
 
 ]
 dependencies = [
-    "tutor>=19.0.0,<21.0.0",
+    "tutor>=19.0.0,<22.0.0",
 ]
-optional-dependencies = { dev = ["tutor[dev]>=19.0.0,<21.0.0"] }
+optional-dependencies = { dev = ["tutor[dev]>=19.0.0,<22.0.0"] }
 
 # These fields will be set by hatch_build.py
 dynamic = ["version"]

--- a/plugins/tutor-contrib-paragon/README.rst
+++ b/plugins/tutor-contrib-paragon/README.rst
@@ -63,7 +63,7 @@ To use this plugin, ensure you're running compatible versions of Open edX and it
 
 ::
 
-    tutor>=19.0.0,<21.0.0
+    tutor>=19.0.0,<22.0.0
 
 This constraint will be revisited once as future versions of Tutor are released and this plugin's functionality is verified against them.
 

--- a/plugins/tutor-contrib-paragon/pyproject.toml
+++ b/plugins/tutor-contrib-paragon/pyproject.toml
@@ -27,11 +27,11 @@ classifiers = [
 
 ]
 dependencies = [
-    "tutor>=19.0.0,<21.0.0",
-    "tutor-mfe>=20.1.0,<21.0.0",
+    "tutor>=19.0.0,<22.0.0",
+    "tutor-mfe>=20.1.0,<22.0.0",
 ]
 
-optional-dependencies = { dev = ["tutor[dev]>=19.0.0,<21.0.0", "pytest>=8.3.4", "pytest-order>=1.3.0", "requests>=2.32.2"] }
+optional-dependencies = { dev = ["tutor[dev]>=19.0.0,<22.0.0", "pytest>=8.3.4", "pytest-order>=1.3.0", "requests>=2.32.2"] }
 
 # These fields will be set by hatch_build.py
 dynamic = ["version"]


### PR DESCRIPTION
This will introduce support for tutor v21 for lti store and paragon plugins.