### PR TITLE
fix: lint and format

### DIFF
--- a/plugins/tutor-contrib-ltistore/Makefile
+++ b/plugins/tutor-contrib-ltistore/Makefile
@@ -1,25 +1,24 @@
 .DEFAULT_GOAL := help
 .PHONY: docs
 SRC_DIRS = ./tutor_ltistore
-BLACK_OPTS = --exclude templates ${SRC_DIRS}
 
 # Warning: These checks are not necessarily run on every PR.
 test: test-lint test-types test-format  # Run some static checks.
 
 test-format: ## Run code formatting tests
-	black --check --diff $(BLACK_OPTS)
+	ruff format --check --diff $(SRC_DIRS)
 
 test-lint: ## Run code linting tests
-	pylint --errors-only --enable=unused-import,unused-argument --ignore=templates --ignore=docs/_ext ${SRC_DIRS}
+	ruff check ${SRC_DIRS}
 
 test-types: ## Run type checks.
 	mypy --exclude=templates --ignore-missing-imports --implicit-reexport --strict ${SRC_DIRS}
 
 format: ## Format code automatically
-	black $(BLACK_OPTS)
+	ruff format ${SRC_DIRS}
 
-isort: ##  Sort imports. This target is not mandatory because the output may be incompatible with black formatting. Provided for convenience purposes.
-	isort --skip=templates ${SRC_DIRS}
+fix-lint: ## Fix lint errors automatically
+	ruff check --fix ${SRC_DIRS}
 
 ESCAPE = 
 help: ## Print this help

--- a/plugins/tutor-contrib-ltistore/tutor_ltistore/plugin.py
+++ b/plugins/tutor-contrib-ltistore/tutor_ltistore/plugin.py
@@ -1,7 +1,6 @@
 import os
 from glob import glob
 
-import click
 import importlib_resources
 from tutor import hooks
 

--- a/plugins/tutor-contrib-paragon/Makefile
+++ b/plugins/tutor-contrib-paragon/Makefile
@@ -1,25 +1,24 @@
 .DEFAULT_GOAL := help
 .PHONY: docs
 SRC_DIRS = ./tutorparagon
-BLACK_OPTS = --exclude templates ${SRC_DIRS}
 
 # Warning: These checks are not necessarily run on every PR.
 test: test-lint test-types test-format  # Run some static checks.
 
 test-format: ## Run code formatting tests
-	black --check --diff $(BLACK_OPTS)
+	ruff format --check --diff $(SRC_DIRS)
 
 test-lint: ## Run code linting tests
-	pylint --errors-only --enable=unused-import,unused-argument --ignore=templates --ignore=docs/_ext ${SRC_DIRS}
+	ruff check ${SRC_DIRS}
 
 test-types: ## Run type checks.
 	mypy --exclude=templates --ignore-missing-imports --implicit-reexport --strict ${SRC_DIRS}
 
 format: ## Format code automatically
-	black $(BLACK_OPTS)
+	ruff format ${SRC_DIRS}
 
-isort: ##  Sort imports. This target is not mandatory because the output may be incompatible with black formatting. Provided for convenience purposes.
-	isort --skip=templates ${SRC_DIRS}
+fix-lint: ## Fix lint errors automatically
+	ruff check --fix ${SRC_DIRS}
 
 unittest: ## Run code tests cases
 	pytest tests --ignore=tests/integration

--- a/plugins/tutor-contrib-paragon/tutorparagon/plugin.py
+++ b/plugins/tutor-contrib-paragon/tutorparagon/plugin.py
@@ -1,7 +1,6 @@
 import os
 from glob import glob
 
-import click
 import importlib_resources
 from tutor import hooks
 from tutor import config as tutor_config


### PR DESCRIPTION
Right now jobs are failing because tutor now uses ruff instead of black, isort and pylint and we're still using old tools in test pipeline.
This will introduce ruff to format and lint for test.