### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ltistore-tests.yml
+++ b/.github/workflows/ltistore-tests.yml
@@ -17,9 +17,9 @@ jobs:
         # All steps will run from this directory
         working-directory: plugins/tutor-contrib-ltistore
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip

--- a/.github/workflows/run-paragon-plugin-tests.yml
+++ b/.github/workflows/run-paragon-plugin-tests.yml
@@ -17,10 +17,10 @@ jobs:
         working-directory: plugins/tutor-contrib-paragon
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary

- Pins all pinnable GitHub Action \`uses:\` refs to full commit SHAs with human-readable version comments
- Generated using [pinact](https://github.com/suzuki-shunsuke/pinact) v3.10.0

## Context

Part of the org-wide SHA-pinning migration: openedx/.github#165

Resolves https://github.com/openedx/.github/issues/165

Reusable workflow calls (\`openedx/.github/.github/workflows/...@master\`) are intentionally left unpinned — they track the org's shared workflows by design.

## Test plan

- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)