### PR TITLE
fix!: Unify default for compiling vs serving themes

### DIFF
--- a/plugins/tutor-contrib-paragon/README.rst
+++ b/plugins/tutor-contrib-paragon/README.rst
@@ -127,7 +127,7 @@ All configuration variables are defined via Tutor:
     Base path for compiled output. Default: ``env/plugins/paragon/compiled-themes``.
 
 ``PARAGON_ENABLED_THEMES``
-    List of theme folders to compile and serve. Default: ``[]``.
+    List of theme folders to compile and serve. Default: ``['light']``.
 
 ``MFE_HOST_EXTRA_FILES``
     Whether to serve compiled themes via Tutor's MFE web server. Default: ``true``.

--- a/plugins/tutor-contrib-paragon/tutorparagon/plugin.py
+++ b/plugins/tutor-contrib-paragon/tutorparagon/plugin.py
@@ -27,7 +27,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("PARAGON_COMPILED_THEMES_PATH", "env/plugins/paragon/compiled-themes"),
         # List of enabled themes to compile and serve
         # Only themes listed here will be processed, even if others exist in sources
-        ("PARAGON_ENABLED_THEMES", []),
+        ("PARAGON_ENABLED_THEMES", ['light']),
         # Paragon Builder Docker image
         # This image is used to compile themes and should be built with `tutor images build paragon-builder`
         ("PARAGON_BUILDER_IMAGE", "paragon-builder:latest"),


### PR DESCRIPTION
## Background

Context: https://github.com/openedx/openedx-tutor-plugins/pull/67#discussion_r3252487738

I haven't tested this yet. Honestly I haven't thought hard about whether it's the right fix or not. Just wanted to open this to start the discussion and keep track of the discrepancy.

## Description

Before, the effective defaults were:

* Compile nothing (`[]`)
* Serve just the light theme (`['light']`)

which made the `PARAGON_ENABLED_THEMES` setting somewhat confusing.

This changes the default to `['light']` for both.

BREAKING CHANGE: Running `tutor paragon-build-tokens` with default settings will now compile the light theme. Before, it would compile nothing. As before, tutor-contrib-paragon still serves just the light theme by default.

## AI use

None